### PR TITLE
Add unit tests for components using Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@eslint/js": "^9.39.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
@@ -1697,6 +1698,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@eslint/js": "^9.39.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",

--- a/src/context/WondersContext.jsx
+++ b/src/context/WondersContext.jsx
@@ -32,7 +32,7 @@ export function WondersProvider(props) {
 // WondersProvider is used in main.jsx to wrap around the app, so all components can access the wonders data through context.
 // WondersProvider fetches the wonders data from the API when it first renders and stores it in state, then provides it to any child components that consume the context.
 //
-// ----------------------------------------------------------------------------https://claude.ai/chat/5db0f0e7-e7d4-438e-a804-fc945a024292
+// ----------------------------------------------------------------------------
 //
 // Example usage in a component:
 //

--- a/src/context/WondersContext.jsx
+++ b/src/context/WondersContext.jsx
@@ -32,7 +32,7 @@ export function WondersProvider(props) {
 // WondersProvider is used in main.jsx to wrap around the app, so all components can access the wonders data through context.
 // WondersProvider fetches the wonders data from the API when it first renders and stores it in state, then provides it to any child components that consume the context.
 //
-// ----------------------------------------------------------------------------
+// ----------------------------------------------------------------------------https://claude.ai/chat/5db0f0e7-e7d4-438e-a804-fc945a024292
 //
 // Example usage in a component:
 //

--- a/src/tests/BritannicaButton.test.jsx
+++ b/src/tests/BritannicaButton.test.jsx
@@ -1,0 +1,42 @@
+import { render, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import BritannicaButton from '../components/BritannicaButton';
+
+describe('BritannicaButton', () => {
+  const mockItem = {
+    name: 'Great Wall of China',
+    links: {
+      britannica: 'https://www.britannica.com/topic/Great-Wall-of-China',
+    },
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal('open', vi.fn());
+  });
+
+  it('renders a button with the text "Britannica"', () => {
+    const { container } = render(<BritannicaButton item={mockItem} />);
+    expect(within(container).getByText('Britannica')).toBeTruthy();
+  });
+
+  it('opens the Britannica link in a new tab when clicked', () => {
+    const { container } = render(<BritannicaButton item={mockItem} />);
+    within(container).getByText('Britannica').click();
+    expect(window.open).toHaveBeenCalledWith(
+      'https://www.britannica.com/topic/Great-Wall-of-China',
+      '_blank'
+    );
+  });
+
+  it('does not throw when britannica link is missing', () => {
+    const { container } = render(<BritannicaButton item={{ name: 'X', links: {} }} />);
+    container.querySelector('button').click();
+    expect(window.open).toHaveBeenCalledWith(undefined, '_blank');
+  });
+
+  it('does not throw when links is undefined', () => {
+    const { container } = render(<BritannicaButton item={{ name: 'X' }} />);
+    container.querySelector('button').click();
+    expect(window.open).toHaveBeenCalledWith(undefined, '_blank');
+  });
+});

--- a/src/tests/Item.test.jsx
+++ b/src/tests/Item.test.jsx
@@ -1,0 +1,58 @@
+import { render, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Item from '../components/Item';
+
+vi.mock('../components/TripAdvisorButton', () => ({
+  default: () => <button>TripAdvisor</button>,
+}));
+vi.mock('../components/BritannicaButton', () => ({
+  default: () => <button>Britannica</button>,
+}));
+
+describe('Item', () => {
+  const mockItem = {
+    name: 'Machu Picchu',
+    summary: 'An Incan citadel set high in the Andes Mountains.',
+    categories: ['Ancient', 'South America'],
+    links: {
+      images: ['https://example.com/machu-picchu.jpg'],
+    },
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal('open', vi.fn());
+  });
+
+  it('renders the wonder name', () => {
+    const { container } = render(<Item item={mockItem} />);
+    expect(container.textContent).toContain('Machu Picchu');
+  });
+
+  it('renders the summary', () => {
+    const { container } = render(<Item item={mockItem} />);
+    expect(container.textContent).toContain('An Incan citadel set high in the Andes Mountains.');
+  });
+
+  it('renders categories joined by a comma', () => {
+    const { container } = render(<Item item={mockItem} />);
+    expect(container.textContent).toContain('Ancient, South America');
+  });
+
+  it('renders the image with correct src and alt', () => {
+    const { container } = render(<Item item={mockItem} />);
+    const img = container.querySelector('img');
+    expect(img.alt).toBe('Machu Picchu');
+    expect(img.src).toBe('https://example.com/machu-picchu.jpg');
+  });
+
+  it('renders TripAdvisor and Britannica buttons', () => {
+    const { container } = render(<Item item={mockItem} />);
+    expect(container.textContent).toContain('TripAdvisor');
+    expect(container.textContent).toContain('Britannica');
+  });
+
+  it('renders without crashing when optional fields are missing', () => {
+    const { container } = render(<Item item={{ name: 'Mystery Wonder' }} />);
+    expect(container.textContent).toContain('Mystery Wonder');
+  });
+});

--- a/src/tests/ItemCard.test.jsx
+++ b/src/tests/ItemCard.test.jsx
@@ -1,0 +1,59 @@
+import { render, within } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ItemCard from '../components/ItemCard';
+
+describe('ItemCard', () => {
+  const mockItem = {
+    name: 'Petra',
+    location: 'Jordan',
+    time_period: 'Nabataean Kingdom',
+    build_year: '312 BC',
+    summary: 'A famous archaeological city in southern Jordan.',
+    categories: ['Ancient', 'Middle East'],
+    links: {
+      images: ['https://example.com/petra.jpg'],
+    },
+  };
+
+  it('renders the wonder name', () => {
+    const { container } = render(<ItemCard item={mockItem} />);
+    expect(container.textContent).toContain('Petra');
+  });
+
+  it('renders the location', () => {
+    const { container } = render(<ItemCard item={mockItem} />);
+    expect(container.textContent).toContain('Jordan');
+  });
+
+  it('renders the time period', () => {
+    const { container } = render(<ItemCard item={mockItem} />);
+    expect(container.textContent).toContain('Nabataean Kingdom');
+  });
+
+  it('renders the build year', () => {
+    const { container } = render(<ItemCard item={mockItem} />);
+    expect(container.textContent).toContain('312 BC');
+  });
+
+  it('renders categories joined by a comma', () => {
+    const { container } = render(<ItemCard item={mockItem} />);
+    expect(container.textContent).toContain('Ancient, Middle East');
+  });
+
+  it('renders the summary', () => {
+    const { container } = render(<ItemCard item={mockItem} />);
+    expect(container.textContent).toContain('A famous archaeological city in southern Jordan.');
+  });
+
+  it('renders the image with correct src and alt text', () => {
+    const { container } = render(<ItemCard item={mockItem} />);
+    const img = container.querySelector('img');
+    expect(img.alt).toBe('Petra');
+    expect(img.src).toBe('https://example.com/petra.jpg');
+  });
+
+  it('renders without crashing when optional fields are missing', () => {
+    const { container } = render(<ItemCard item={{ name: 'Unknown Wonder' }} />);
+    expect(container.textContent).toContain('Unknown Wonder');
+  });
+});

--- a/src/tests/ItemList.test.jsx
+++ b/src/tests/ItemList.test.jsx
@@ -1,20 +1,34 @@
-//Add unit tests for ItemList component
 import { render, screen } from "@testing-library/react";
 import { test, expect } from "vitest";
 import "@testing-library/jest-dom/vitest";
+import { WondersContext } from "../context/WondersContext";
 import ItemList from "../ItemList";
 
+const mockWonders = [
+  { id: 1, name: "Great Pyramid of Giza", categories: ["Ancient"], summary: "An ancient wonder.", links: { images: [] } },
+  { id: 2, name: "Taj Mahal", categories: ["Modern"], summary: "A beautiful mausoleum.", links: { images: [] } },
+  { id: 3, name: "Christ the Redeemer", categories: ["Modern"], summary: "A famous statue.", links: { images: [] } },
+];
+
+function renderWithContext() {
+  return render(
+    <WondersContext.Provider value={{ wonders: mockWonders }}>
+      <ItemList />
+    </WondersContext.Provider>
+  );
+}
+
 test("renders Great Pyramid of Giza", () => {
-  render(<ItemList />);
+  renderWithContext();
   expect(screen.getAllByText(/Great Pyramid of Giza/i).length).toBeGreaterThan(0);
 });
 
 test("renders Taj Mahal", () => {
-  render(<ItemList />);
+  renderWithContext();
   expect(screen.getAllByText(/Taj Mahal/i).length).toBeGreaterThan(0);
 });
 
 test("renders Christ the Redeemer", () => {
-  render(<ItemList />);
+  renderWithContext();
   expect(screen.getAllByText(/Christ the Redeemer/i).length).toBeGreaterThan(0);
 });

--- a/src/tests/TripAdvisorButton.test.jsx
+++ b/src/tests/TripAdvisorButton.test.jsx
@@ -1,0 +1,42 @@
+import { render, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import TripAdvisorButton from '../components/TripAdvisorButton';
+
+describe('TripAdvisorButton', () => {
+  const mockItem = {
+    name: 'Colosseum',
+    links: {
+      trip_advisor: 'https://www.tripadvisor.com/Attraction_Review-Colosseum',
+    },
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal('open', vi.fn());
+  });
+
+  it('renders a button with the text "TripAdvisor"', () => {
+    const { container } = render(<TripAdvisorButton item={mockItem} />);
+    expect(within(container).getByText('TripAdvisor')).toBeTruthy();
+  });
+
+  it('opens the TripAdvisor link in a new tab when clicked', () => {
+    const { container } = render(<TripAdvisorButton item={mockItem} />);
+    within(container).getByText('TripAdvisor').click();
+    expect(window.open).toHaveBeenCalledWith(
+      'https://www.tripadvisor.com/Attraction_Review-Colosseum',
+      '_blank'
+    );
+  });
+
+  it('does not throw when trip_advisor link is missing', () => {
+    const { container } = render(<TripAdvisorButton item={{ name: 'X', links: {} }} />);
+    container.querySelector('button').click();
+    expect(window.open).toHaveBeenCalledWith(undefined, '_blank');
+  });
+
+  it('does not throw when links is undefined', () => {
+    const { container } = render(<TripAdvisorButton item={{ name: 'X' }} />);
+    container.querySelector('button').click();
+    expect(window.open).toHaveBeenCalledWith(undefined, '_blank');
+  });
+});


### PR DESCRIPTION
Add unit tests for components using Vitest
Added unit tests for BritannicaButton, TripAdvisorButton, Item, ItemCard, and ItemsList components. Fixed ItemsList tests by wrapping with WondersContext.Provider mock data.